### PR TITLE
Upgrade dbus package to version 1.0.5

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,7 @@ var debug = function(object) {
     _debug("\n"+util.inspect(object, showHidden=false, depth=2, colorize=true)+"\n");
 };
 var warn = require('debug')('warn');
-var DBus = require('dbus'); 
-var dbus = new DBus();
+var DBus = require('dbus');
 var events = require('events');
 
 var nm = {};
@@ -47,21 +46,20 @@ var iface_cache = {};
  * Wait for dbus service
  */
 waitForService = function (findServiceName, timeoutDelay, intervalDelay, callback) {
-  bus.getInterface('org.freedesktop.DBus', '/', 'org.freedesktop.DBus', function(err, iface) {
+  bus.getInterface('org.freedesktop.DBus', '/org/freedesktop/DBus', 'org.freedesktop.DBus', function(err, iface) {
     var timeout, interval;
 
     if(err) { return callback(err); } else {
       var checkService = function (callback) {
         debug("looking for dbus service");
-        iface.ListNames['finish'] = function(serviceList) {
+        iface.ListNames(function(err, serviceList) {
           for (index = 0; index < serviceList.length; ++index) {
             if(serviceList[index] === findServiceName) {
               return callback(true);
             }
           }
           return callback(false);
-        }
-        iface.ListNames();
+        });
       }
 
       timeout = setTimeout(function () {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^0.9.0",
-    "dbus": "^0.2.9",
+    "dbus": "^1.0.0",
     "debug": ">=2.6.9",
     "netmask": "^1.0.4",
     "node.extend": "^1.0.10"


### PR DESCRIPTION
The dbus package got a new stable release with some minor changes.

This patch updates the package and fixes some minor issues that appeared
after the upgrade like `no such interface` error when requesting the '/'
object path from `org.freedesktop.DBus`. Besides that also fix the usage
of the ListNames function that would cause and endless loop until the
timeout steps in. By using the callback schema, this is prevented and
the `['finish']` way of doing things becomes obsolete.